### PR TITLE
added search field not case sensitive

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
 
   def index
     @users = User.all
-    if params[:search]
-      @users = User.search(params[:search])
+    if params[:search_by_name]
+      @users = User.search_by_name(params[:search_by_name])
     else
       @users = User.all
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,11 @@ class UsersController < ApplicationController
 
   def index
     @users = User.all
+    if params[:search]
+      @users = User.search(params[:search])
+    else
+      @users = User.all
+    end
   end
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   validates :name, :phone, presence: true
   validates :name, format: { with: /\A[a-zA-Z]+\z/ }
   validates :phone, numericality: { only_integer: true }
-  scope :search_by_name, ->(query) { where('name ilike ?', "#{query}%") }
+  scope :search_by_name, ->(query) { where('name ilike ?', "%#{query}%") }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   validates :name, :phone, presence: true
   validates :name, format: { with: /\A[a-zA-Z]+\z/ }
   validates :phone, numericality: { only_integer: true }
-  scope :search, ->(query) { where('name ilike ?', "#{query}%") }
+  scope :search_by_name, ->(query) { where('name ilike ?', "#{query}%") }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,6 @@
 class User < ApplicationRecord
   validates :name, :phone, presence: true
-  validates :name, format: { with: /\A[a-zA-Z]+\z/}
+  validates :name, format: { with: /\A[a-zA-Z]+\z/ }
   validates :phone, numericality: { only_integer: true }
-
-  def self.search(query)
-    where('name ilike ?', "#{query}%")
-  end
-
+  scope :search, ->(query) { where('name ilike ?', "#{query}%") }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,10 @@
 class User < ApplicationRecord
-    validates :name, :phone, presence: true
-    validates :name, format: { with: /\A[a-zA-Z]+\z/}
-    validates :phone, numericality: { only_integer: true }
+  validates :name, :phone, presence: true
+  validates :name, format: { with: /\A[a-zA-Z]+\z/}
+  validates :phone, numericality: { only_integer: true }
+
+  def self.search(query)
+    where('name ilike ?', "#{query}%")
+  end
+
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,11 @@
 
+<%= form_tag(users_path, :method => :get) do %>
+  <p>
+    <%= text_field_tag :search, params[:search] %>
+    <%= submit_tag 'Search' %>
+  </p>
+<% end %>
+
 <table>
     <thead>
         <tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 
 <%= form_tag(users_path, :method => :get) do %>
   <p>
-    <%= text_field_tag :search, params[:search] %>
+    <%= text_field_tag :search_by_name, params[:search_by_name] %>
     <%= submit_tag 'Search' %>
   </p>
 <% end %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,16 +9,30 @@ RSpec.describe UsersController, type: :controller do
 
     it 'finds by name Ed' do
       #action
-      get :index, params: { search: 'Ed' }
+      get :index, params: { search_by_name: 'Ed' }
       #assert
       assigns(:users).should eq([user1, user2])
     end
 
     it 'finds by name with da' do
       #action
-      get :index, params: { search: 'Da' }
+      get :index, params: { search_by_name: 'Da' }
       #assert
       assigns(:users).should eq([user])
+    end
+
+    it 'when does not find any user' do
+      #action
+      get :index, params: { search_by_name: 'f' }
+      #assert
+      expect(nil).to be_nil
+    end
+
+    it 'when search is empty' do
+      #action
+      get :index, params: { search_by_name: ' ' }
+      #assert
+      expect(assigns(:users)).to be_empty
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UsersController, type: :controller do
       assigns(:users).should eq([user])
     end
 
-    it 'finds by name with da' do
+    it 'finds by name with iel' do
       #action
       get :index, params: { search_by_name: 'iel' }
       #assert

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+  describe 'finds a searched user by name' do
+    #prepare
+    let!(:user) { create(:user, name: 'Dan') }
+    let!(:user1) { create(:user, name: 'Edimo') }
+    let!(:user2) { create(:user, name: 'Edmilson') }
+
+    it 'finds by name Ed' do
+      #action
+      get :index, params: { search: 'Ed' }
+      #assert
+      assigns(:users).should eq([user1, user2])
+    end
+
+    it 'finds by name with da' do
+      #action
+      get :index, params: { search: 'Da' }
+      #assert
+      assigns(:users).should eq([user])
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe UsersController, type: :controller do
   describe 'finds a searched user by name' do
     #prepare
-    let!(:user) { create(:user, name: 'Dan') }
+    let!(:user) { create(:user, name: 'Daniel') }
     let!(:user1) { create(:user, name: 'Edimo') }
     let!(:user2) { create(:user, name: 'Edmilson') }
 
@@ -17,6 +17,13 @@ RSpec.describe UsersController, type: :controller do
     it 'finds by name with da' do
       #action
       get :index, params: { search_by_name: 'Da' }
+      #assert
+      assigns(:users).should eq([user])
+    end
+
+    it 'finds by name with da' do
+      #action
+      get :index, params: { search_by_name: 'iel' }
       #assert
       assigns(:users).should eq([user])
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name {"Dan"}
-    phone {"996745953"}
+    name { 'Dan' }
+    phone { '996745953' }
   end
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
-
   describe 'GET /users' do
     it 'returns success status' do
       get '/users'
@@ -42,7 +41,5 @@ RSpec.describe 'Users', type: :request do
       expect(user.name).to eq(params[:name])
       expect(response).to redirect_to action: 'index'
     end
-
   end
-
 end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe 'DELETE #destroy' do
-  let!(:user) { create(:user) }
+    let!(:user) { create(:user) }
 
   it 'deletes the user' do
     expect { delete("/users/#{user.id}") }.to change(User, :count).from(1).to(0)


### PR DESCRIPTION
Fix issue: #10 
find by name

At home page, type some string and show only itens that have that string. Example, edimo, Edimilson and Daniel. If searh for ed shoud return edimo and Edmilson. The search is not case sensitive

Test coverage:
![image](https://user-images.githubusercontent.com/6463001/91994121-e4c39680-ed3e-11ea-8491-ec8907568035.png)

link Heroku app: https://fierce-springs-99712.herokuapp.com/